### PR TITLE
Add support for composite indexes in models

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ To make it a unique index:
 }
 ```
 
+#### Composite / Compound Indexes
+
+You can also define composite indexes (or multi-column indexes) on your model by adding an `indexes` static property array. This is useful when you want to create an index across multiple fields.
+
+```js
+export class Product {
+  static properties = {
+    tenantId: { type: String },
+    categoryId: { type: String },
+    name: { type: String },
+  }
+
+  static indexes = [
+    // Array syntax for standard composite index
+    ['tenantId', 'categoryId'],
+    // Object syntax if you need it to be unique
+    { columns: ['tenantId', 'name'], unique: true }
+  ]
+}
+```
+
 ## Using raw statements
 
 ```js

--- a/cmigrations.js
+++ b/cmigrations.js
@@ -83,6 +83,35 @@ export class ClassMigrations {
         await this.checkForIndex(tableName, propName, prop)
       }
     }
+    if (clz.indexes) {
+      for (const indexDef of clz.indexes) {
+        await this.checkCompositeIndex(tableName, indexDef)
+      }
+    }
+  }
+
+  async checkCompositeIndex(tableName, indexDef) {
+    let columns = []
+    let unique = false
+    if (Array.isArray(indexDef)) {
+      columns = indexDef
+    } else {
+      columns = indexDef.columns
+      unique = indexDef.unique
+    }
+    if (!columns || columns.length === 0) return
+
+    let indexName = `${tableName}_${columns.join('_')}_idx`
+    let stmt = `PRAGMA index_list("${tableName}")`
+    let idx = await this.db.prepare(stmt).run()
+    let existingIndex = idx.results.find((i) => i.name === indexName)
+    if (existingIndex) {
+      return
+    }
+    stmt = `CREATE${unique ? ' UNIQUE' : ''} INDEX IF NOT EXISTS ${indexName} ON ${tableName} (${columns.join(', ')})`
+    console.log("composite index does not exist, creating it", stmt)
+    let dr = await this.db.prepare(stmt).run()
+    console.log('COMPOSITE INDEX CREATED', dr)
   }
 
   async checkForIndex(tableName, propName, prop, col) {

--- a/example/models/product.js
+++ b/example/models/product.js
@@ -33,4 +33,9 @@ export class Product {
       type: Object,
     },
   }
+
+  static indexes = [
+    ['categoryId', 'name'],
+    { columns: ['name', 'value'], unique: true }
+  ]
 }

--- a/test/test1.js
+++ b/test/test1.js
@@ -22,8 +22,12 @@ export async function test1(c) {
   assert(r.productsTable)
   assert(r.productsTable.length > 0)
   assert(r.productsTable.some(p => p.name == 'categoryId'))
-  assert(r.indexes.length == 1)
+  assert(r.indexes.length == 3) // primary key autoindex + 2 compound indexes
   await new Promise(resolve => setTimeout(resolve, 10000))
+
+  // verify compound indexes
+  assert(r.indexes.some(i => i.name === 'products_categoryId_name_idx'))
+  assert(r.indexes.some(i => i.name === 'products_name_value_idx' && i.unique === 1))
 
   // now let's add an index and make sure it updates
   r = await c.api.fetch(`/?addIndex=true`, {
@@ -40,6 +44,6 @@ export async function test1(c) {
     },
   })
   console.log('r4:', r)
-  assert(r.indexes.length == 2)
+  assert(r.indexes.length == 4) // autoindex, 2 compound, 1 regular
 
 }


### PR DESCRIPTION
Added support for composite (multi-column) indexes defined in the model classes using a `static indexes` array. Supports both array syntax for standard composite indexes and object syntax for unique composite indexes. This includes updates to the core `ClassMigrations` logic to create the indices, updated documentation, and testing scripts to ensure proper functionality. Cleaned up devDependencies from earlier plan.

---
*PR created automatically by Jules for task [2421626312275778272](https://jules.google.com/task/2421626312275778272) started by @treeder*